### PR TITLE
Feature GitHub Pages CI deployment

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,17 +1,14 @@
-name: CI Tests
+name: CI Development
 
 on:
-  push:
   pull_request:
-    branches: [master, develop]
+    branches:
+    - master
+    - develop
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    # strategy:
-    #   matrix:
-    #     node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v1
@@ -24,6 +21,11 @@ jobs:
       - name: install
         run: |
           yarn install
+
+      - name: build
+        run: |
+          yarn build
+
       - name: test
         run: |
           yarn test

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '14'
 
       - name: install
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: CI Publish
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: install
+        run: |
+          yarn install
+
+      - name: build
+        run: |
+          yarn build
+
+      - name: test
+        run: |
+          yarn test
+        env:
+          NODE_ENV: production
+          CI: true
+
+      - name: Deploy with gh-pages
+        run: |
+          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          npx gh-pages -d build -u "github-actions-bot <support+actions@github.com>"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '14'
 
       - name: install
         run: |


### PR DESCRIPTION
This PR introduces an automatic deployment flow for GitHub Pages.

Prior to merging, the following tasks require attention:

- [ ] Specify to be used node version (currently using node 14)