### PR TITLE
Adjust filter button position

### DIFF
--- a/src/components/drawers/FilterDrawer.scss
+++ b/src/components/drawers/FilterDrawer.scss
@@ -48,9 +48,14 @@ header {
   margin-left: -5px !important;
 }
 
+.option-button {
+  display: flex;
+  flex-direction: row-reverse;
+}
+
 @media only screen and (max-width: 921px) {
   .option-button {
-    width: 60%;
+    width: 100%;
     margin-top: 0px !important;
   }
 }

--- a/src/components/drawers/FilterDrawer.tsx
+++ b/src/components/drawers/FilterDrawer.tsx
@@ -39,7 +39,7 @@ export const FilterDrawer: React.FC = () => {
       <Box className='responsive-filters'>
         <Drawer isOpen={isOpen} placement='right' onClose={onClose}>
           <DrawerOverlay />
-          <DrawerContent backgroundColor='#fffafa'>
+          <DrawerContent className='filter-modal' backgroundColor='#fffafa'>
             <DrawerCloseButton />
             <DrawerHeader mt={10}>Technologies</DrawerHeader>
             <TechList />

--- a/src/pages/views/RadarView.scss
+++ b/src/pages/views/RadarView.scss
@@ -17,7 +17,7 @@
     overflow-x: auto;
   }
   .how-to-button {
-    right: 0 !important;
+    right: 150px !important;
   }
   .tabsComponents p {
     width: auto;
@@ -47,7 +47,7 @@
     overflow-x: auto;
   }
   .how-to-button {
-    right: 0 !important;
+    right: 150px !important;
   }
   .tabsComponents p {
     width: auto;
@@ -78,7 +78,7 @@
     overflow-x: auto;
   }
   .how-to-button {
-    right: 0 !important;
+    right: 150px !important;
   }
   .tabsComponents p {
     width: auto;
@@ -172,5 +172,11 @@
   .tabsComponents {
     margin: 80px 0 0 80px !important;
     max-width: 290px !important;
+  }
+}
+#chakra-modal-3.filter-modal {
+  top: 75px !important;
+  @media only screen and (max-width: 767px) {
+    top: 155px !important;
   }
 }


### PR DESCRIPTION
Having the filter button right on top of the filter actions seems intuitive. When the filter options modal is opened it should also be moved lower to keep the filter button visible.

**Screenshots**

<img width="1512" alt="Screenshot 2022-08-25 at 09 28 36" src="https://user-images.githubusercontent.com/4943363/186591289-e33af45c-3039-460c-ba61-e7372cf37531.png">


<img width="703" alt="Screenshot 2022-08-25 at 09 28 54" src="https://user-images.githubusercontent.com/4943363/186591310-552771b6-afd6-4356-8487-5a4676976fd1.png">
