### PR TITLE
Reset button is too prominent and always visible

### DIFF
--- a/src/components/drawers/filter/CustomFilter.tsx
+++ b/src/components/drawers/filter/CustomFilter.tsx
@@ -374,6 +374,7 @@ export const CustomFilter: React.FC = () => {
         borderBottomWidth: 1,
         paddingBottom: 5,
         display: 'flex',
+        flexDirection: 'column',
         // flexWrap: 'wrap',
         alignItems: 'center'
       }}

--- a/src/components/drawers/filter/CustomFilter.tsx
+++ b/src/components/drawers/filter/CustomFilter.tsx
@@ -155,6 +155,10 @@ export const CustomFilter: React.FC = () => {
     dataFilter === null ? 'all' : dataFilter
   );
 
+  // track active filters
+  const [customfilterSelected, setCustomFilterSelected] =
+    useState<boolean>(false);
+
   /**
    * This is our filtering logic
    */
@@ -256,6 +260,7 @@ export const CustomFilter: React.FC = () => {
 
     // set filter
     setFilteredBlips(isFiltered, filtered);
+    setCustomFilterSelected(isFiltered);
   }, [
     useCaseKey,
     disasterKey,
@@ -615,26 +620,22 @@ export const CustomFilter: React.FC = () => {
         </div>
       </div>
 
-      <div>
-        <button
-          type='button'
-          style={{
-            borderColor: 'lightgrey',
-            borderWidth: 1,
-            borderStyle: 'solid',
-            padding: '10px 20px',
-            backgroundColor: '#3182ce',
-            cursor: 'pointer',
-            borderRadius: 5,
-            color: 'white',
-            marginTop: 5,
-            marginBottom: 3
-          }}
-          onClick={onResetFilter}
-        >
-          Reset
-        </button>
-      </div>
+      {customfilterSelected && (
+        <div>
+          <button
+            type='button'
+            style={{
+              padding: '10px 20px',
+              cursor: 'pointer',
+              color: 'blue',
+              margin: '5px 0 3px'
+            }}
+            onClick={onResetFilter}
+          >
+            Reset
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/drawers/tech/TechList.scss
+++ b/src/components/drawers/tech/TechList.scss
@@ -1,18 +1,8 @@
 .resetTechFilterButton {
-  margin-top: 10px;
-  margin-right: 16px;
-  // border: none;
-  border: 1px solid lightgrey;
-  background-color: #3182ce;
+  margin: 10px 16px 0 10px;
+  border: none;
   padding: 10px 20px;
-  color: snow;
+  color: blue;
   font-size: 15px;
   cursor: pointer;
-  transition: all 0.4s;
-  border-radius: 5px;
-  margin-left: 10px;
-
-  &:hover {
-    opacity: 0.6;
-  }
 }

--- a/src/components/drawers/tech/TechList.tsx
+++ b/src/components/drawers/tech/TechList.tsx
@@ -123,7 +123,7 @@ export const TechList: React.FC<{ showTitle?: boolean }> = ({
           })}
         </ScrollableDiv>
       </div>
-      {techFilters.length && (
+      {Boolean(techFilters.length) && (
         <button
           onClick={resetTech}
           type='button'

--- a/src/components/drawers/tech/TechList.tsx
+++ b/src/components/drawers/tech/TechList.tsx
@@ -123,13 +123,15 @@ export const TechList: React.FC<{ showTitle?: boolean }> = ({
           })}
         </ScrollableDiv>
       </div>
-      <button
-        onClick={resetTech}
-        type='button'
-        className={'resetTechFilterButton'}
-      >
-        Reset
-      </button>
+      {techFilters.length && (
+        <button
+          onClick={resetTech}
+          type='button'
+          className={'resetTechFilterButton'}
+        >
+          Reset
+        </button>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
The reset button take up more space than it needs to yet it is not a primary CTA. It also does not need to be visible if no filter option has been selected yet.

![Screenshot 2022-09-05 at 11 27 26](https://user-images.githubusercontent.com/4943363/188404784-bfef0834-1a1a-4b7e-a91c-71efc409fefa.png)


![Screenshot 2022-09-05 at 11 27 47](https://user-images.githubusercontent.com/4943363/188404831-32a54a63-6954-43b0-af60-ba23bca60a18.png)
