### PR TITLE
Move radar title to the top of the page.

### DIFF
--- a/src/components/drawers/FilterDrawer.scss
+++ b/src/components/drawers/FilterDrawer.scss
@@ -51,6 +51,7 @@ header {
 .option-button {
   display: flex;
   flex-direction: row-reverse;
+  z-index: 1;
 }
 
 @media only screen and (max-width: 921px) {

--- a/src/components/header/AppMobileHeader.tsx
+++ b/src/components/header/AppMobileHeader.tsx
@@ -19,7 +19,8 @@ export const AppMobileHeader: React.FC = () => {
           <UNLogo />
         </Box>
         <Text fontSize='1.2em' fontWeight={500} lineHeight='79px'>
-          Technology Radar
+          {/* Technology Radar */}
+          Frontier Technology Radar for Disaster Risk Reduction (FTR4DRR)
         </Text>
         <Box my={5} mr={5}>
           <UNDPLogo />

--- a/src/components/header/AppMobileHeader.tsx
+++ b/src/components/header/AppMobileHeader.tsx
@@ -18,8 +18,12 @@ export const AppMobileHeader: React.FC = () => {
         <Box my={3} ml={5}>
           <UNLogo />
         </Box>
-        <Text fontSize='1.2em' fontWeight={500} lineHeight='79px'>
-          {/* Technology Radar */}
+        <Text
+          fontSize='1.2em'
+          fontWeight={500}
+          textAlign={'center'}
+          alignSelf={'center'}
+        >
           Frontier Technology Radar for Disaster Risk Reduction (FTR4DRR)
         </Text>
         <Box my={5} mr={5}>

--- a/src/pages/views/RadarView.scss
+++ b/src/pages/views/RadarView.scss
@@ -2,11 +2,11 @@
   display: flex;
   position: absolute;
   justify-content: space-between;
-  top: 20px;
+  top: 15px;
 
   .titleFiller {
     width: 550px;
-    z-index: -9999;
+    z-index: -9;
   }
 }
 
@@ -27,9 +27,6 @@
     width: 90%;
     min-width: 370px;
     overflow-x: auto;
-  }
-  .how-to-button {
-    right: 150px !important;
   }
   .tabsComponents p {
     width: auto;
@@ -57,9 +54,6 @@
     width: 90%;
     min-width: 370px;
     overflow-x: auto;
-  }
-  .how-to-button {
-    right: 150px !important;
   }
   .tabsComponents p {
     width: auto;
@@ -90,7 +84,7 @@
     overflow-x: auto;
   }
   .how-to-button {
-    right: 150px !important;
+    // right: 150px !important;
   }
   .tabsComponents p {
     width: auto;
@@ -129,6 +123,9 @@
     width: 90%;
     min-width: 370px;
     overflow-x: auto;
+  }
+  .radarContainer {
+    margin: 0 auto;
   }
 }
 
@@ -185,10 +182,33 @@
     margin: 80px 0 0 80px !important;
     max-width: 290px !important;
   }
+  .how-to-button {
+    right: 150px !important;
+  }
 }
 #chakra-modal-3.filter-modal {
   top: 75px !important;
   @media only screen and (max-width: 767px) {
     top: 155px !important;
+  }
+}
+
+@media only screen and (max-width: 991px) {
+  .how-to-button {
+    left: 55px;
+    width: fit-content !important;
+  }
+  .radarTitleContainer {
+    flex-direction: column;
+    top: 50px;
+    width: 100%;
+    justify-content: center;
+  }
+  .radarTitle {
+    width: fit-content;
+  }
+  .radarComponents {
+    z-index: 1;
+    margin-top: 80px;
   }
 }

--- a/src/pages/views/RadarView.scss
+++ b/src/pages/views/RadarView.scss
@@ -1,3 +1,15 @@
+.radarTitleContainer {
+  display: flex;
+  position: absolute;
+  justify-content: space-between;
+  top: 20px;
+
+  .titleFiller {
+    width: 550px;
+    z-index: -9999;
+  }
+}
+
 @media only screen and (max-width: 825px) {
   .radarComponents {
     zoom: 80%;

--- a/src/pages/views/RadarView.scss
+++ b/src/pages/views/RadarView.scss
@@ -2,11 +2,11 @@
   display: flex;
   position: absolute;
   justify-content: space-between;
-  top: 15px;
+  top: 20px;
 
   .titleFiller {
     width: 550px;
-    z-index: -9;
+    z-index: -1;
   }
 }
 

--- a/src/pages/views/RadarView.scss
+++ b/src/pages/views/RadarView.scss
@@ -201,8 +201,8 @@
   .radarTitleContainer {
     flex-direction: column;
     top: 50px;
-    width: 100%;
-    justify-content: center;
+    width: 90%;
+    align-items: center;
   }
   .radarTitle {
     width: fit-content;
@@ -210,5 +210,11 @@
   .radarComponents {
     z-index: 1;
     margin-top: 80px;
+  }
+}
+
+@media only screen and (max-width: 767px) {
+  .radarTitleContainer {
+    display: none;
   }
 }

--- a/src/pages/views/RadarView.tsx
+++ b/src/pages/views/RadarView.tsx
@@ -58,7 +58,11 @@ export const RadarView: React.FC<{ loading: boolean }> = ({ loading }) => {
         </Heading>
         <div className='titleFiller' />
       </div>
-      <SimpleGrid alignItems='center' columns={{ sm: 1, md: 1, lg: 2 }}>
+      <SimpleGrid
+        alignItems='center'
+        columns={{ sm: 1, md: 1, lg: 2 }}
+        className='radarContainer'
+      >
         <Box>
           <Box className='radarComponents'>
             {loading && <WaitingForRadar size='620px' />}

--- a/src/pages/views/RadarView.tsx
+++ b/src/pages/views/RadarView.tsx
@@ -45,18 +45,21 @@ export const RadarView: React.FC<{ loading: boolean }> = ({ loading }) => {
 
   return (
     <>
+      <div className='radarTitleContainer'>
+        <Heading
+          fontSize={30}
+          color='DarkSlateGray'
+          textAlign='center'
+          p={15}
+          paddingTop={15}
+          className='radarTitle'
+        >
+          Frontier Technology Radar for Disaster Risk Reduction (FTR4DRR)
+        </Heading>
+        <div className='titleFiller' />
+      </div>
       <SimpleGrid alignItems='center' columns={{ sm: 1, md: 1, lg: 2 }}>
         <Box>
-          <Heading
-            fontSize={30}
-            color='DarkSlateGray'
-            textAlign='center'
-            p={15}
-            paddingTop={15}
-            className='radarTitle'
-          >
-            Frontier Technology Radar for Disaster Risk Reduction (FTR4DRR)
-          </Heading>
           <Box className='radarComponents'>
             {loading && <WaitingForRadar size='620px' />}
             {!loading && <Radar />}


### PR DESCRIPTION
The ‘Frontier Technology Radar for Disaster Risk Reduction (FTR4DRR) should be placed to the top of the page, at the same level as the ‘how to use’ and ‘filter’ buttons.

![localhost_3000_](https://user-images.githubusercontent.com/4943363/189268845-7088eb2d-cf19-413a-a065-5f2b2d96fe7c.png)


![localhost_3000_ (1)](https://user-images.githubusercontent.com/4943363/189268830-4f877f64-7428-474d-850f-737c6edb8fea.png)

