### PR TITLE
space added after every "," seperator

### DIFF
--- a/src/pages/search/SearchBar.tsx
+++ b/src/pages/search/SearchBar.tsx
@@ -33,7 +33,7 @@ export const SearchBar: React.FC = () => {
         merge[existingIndex]['Disaster Cycle'] = merge[existingIndex][
           'Disaster Cycle'
         ]
-          .concat(',')
+          .concat(', ')
           .concat(item['Disaster Cycle']);
       } else {
         //if (typeof item['Disaster Cycle'] == 'string')


### PR DESCRIPTION
space added after every "," seperator for disaster cycle in search page and pop-outs