### PR TITLE
Adjust the layout of the radar page

### DIFF
--- a/src/components/drawers/FilterDrawer.scss
+++ b/src/components/drawers/FilterDrawer.scss
@@ -52,6 +52,10 @@ header {
   display: flex;
   flex-direction: row-reverse;
   z-index: 1;
+
+  button {
+    // margin-right: 0;
+  }
 }
 
 @media only screen and (max-width: 921px) {

--- a/src/components/drawers/FilterDrawer.scss
+++ b/src/components/drawers/FilterDrawer.scss
@@ -52,10 +52,6 @@ header {
   display: flex;
   flex-direction: row-reverse;
   z-index: 1;
-
-  button {
-    // margin-right: 0;
-  }
 }
 
 @media only screen and (max-width: 921px) {

--- a/src/components/header/AppMobileHeader.tsx
+++ b/src/components/header/AppMobileHeader.tsx
@@ -14,6 +14,7 @@ export const AppMobileHeader: React.FC = () => {
         top={0}
         borderBottom='1px solid #E2E8F0'
         backgroundColor='#FFFFFF'
+        zIndex={9}
       >
         <Box my={3} ml={5}>
           <UNLogo />

--- a/src/components/lists/quadrant/QuadrantHorizonList.tsx
+++ b/src/components/lists/quadrant/QuadrantHorizonList.tsx
@@ -96,8 +96,7 @@ export const QuadrantHorizonList: React.FC<Props> = ({ blips, quadIndex }) => {
         borderWidth: 2,
         borderRadius: 10,
         marginTop: 40,
-        padding: 15,
-        maxWidth: 500
+        padding: 15
       }}
     >
       <Tabs variant='enclosed' index={tabIndex} onChange={tabsChangeHandler}>

--- a/src/pages/views/QuadrantView.tsx
+++ b/src/pages/views/QuadrantView.tsx
@@ -37,16 +37,19 @@ export const QuadrantView: React.FC = () => {
   }, [selectedQuadrant]);
 
   return (
-    <div style={{ display: 'flex', flex: 1, padding: 2 }}>
+    <div
+      className='quadrantView'
+      style={{ display: 'flex', flex: 1, padding: 2 }}
+    >
       <BackButton to='RADAR' />
-      <div style={{ flex: 1 }}>
+      <div className='quadrantRadar' style={{ flex: 1 }}>
         <QuadrantRadar />
       </div>
       {(quadIndex === 0 ||
         quadIndex === 1 ||
         quadIndex === 2 ||
         quadIndex === 3) && (
-        <div style={{ flex: '0.75' }}>
+        <div className='horizontalList' style={{ flex: '0.75' }}>
           <QuadrantHorizonList blips={bufferBlips} quadIndex={quadIndex} />
         </div>
       )}

--- a/src/pages/views/RadarView.scss
+++ b/src/pages/views/RadarView.scss
@@ -1,3 +1,21 @@
+.radarContainer {
+  display: flex !important;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  margin: 30px 28px 30px 0;
+  height: max-content;
+
+  .tabsComponents {
+    margin: 0 !important;
+    min-width: 370px !important;
+  }
+
+  .radarComponentsContainer {
+    flex-basis: 75%;
+  }
+}
+
 .radarTitleContainer {
   display: flex;
   position: absolute;
@@ -10,9 +28,24 @@
   }
 }
 
+@media only screen and (max-width: 1080px) {
+  .radarContainer {
+    flex-direction: column;
+    align-items: center;
+    margin-right: 0;
+
+    .tabsComponents {
+      min-width: 80vw !important;
+
+      .chakra-tabs {
+        width: 100%;
+      }
+    }
+  }
+}
+
 @media only screen and (max-width: 825px) {
   .radarComponents {
-    zoom: 80%;
     margin: 0 auto;
     width: 90%;
   }
@@ -39,7 +72,6 @@
 
 @media only screen and (min-width: 768px) {
   .radarComponents {
-    zoom: 80%;
     margin: 0 auto;
     width: 90%;
   }
@@ -67,7 +99,6 @@
 
 @media only screen and (min-width: 600px) {
   .radarComponents {
-    zoom: 80%;
     margin: 0 auto;
     width: 100%;
   }
@@ -82,9 +113,6 @@
     width: 100%;
     min-width: 370px;
     overflow-x: auto;
-  }
-  .how-to-button {
-    // right: 150px !important;
   }
   .tabsComponents p {
     width: auto;
@@ -109,7 +137,6 @@
 
 @media only screen and (max-width: 991px) {
   .radarComponents {
-    zoom: 80%;
     margin: 0 auto;
   }
   .radarTitle {
@@ -131,7 +158,6 @@
 
 @media only screen and (min-width: 1149px) {
   .radarComponents {
-    zoom: 90%;
     width: 100%;
   }
 
@@ -148,7 +174,6 @@
 
 @media only screen and (min-width: 1200px) {
   .radarComponents {
-    zoom: 100%;
     margin: 0 auto;
     width: 90%;
   }
@@ -170,9 +195,6 @@
 }
 
 @media only screen and (min-width: 992px) {
-  .radarComponents {
-    zoom: 80%;
-  }
   .radarTitle {
     font-size: 23px !important;
     margin: 0 0 0 35px !important;

--- a/src/pages/views/RadarView.scss
+++ b/src/pages/views/RadarView.scss
@@ -90,7 +90,6 @@
   .tabsComponents p {
     width: auto;
   }
-
   .tabsComponents h5 {
     font-size: 15px !important;
     font-weight: thin !important;
@@ -125,13 +124,6 @@
   .tabsComponents h6 {
     font-size: 15px !important;
     font-weight: 500 !important;
-  }
-}
-
-@media only screen and (max-width: 600px) {
-  .radarTitle {
-    // font-size: 23px !important;
-    // margin: 160px 20px 20px 20px !important;
   }
 }
 
@@ -185,12 +177,6 @@
   .tabsComponents {
     margin: 80px 0 0 80px !important;
     min-width: 500px !important;
-  }
-}
-
-@media only screen and (max-width: 767px) {
-  .radarTitle {
-    font-size: 23px !important;
   }
 }
 
@@ -300,6 +286,9 @@
       display: none;
     }
   }
+  .radarTitle {
+    font-size: 23px !important;
+  }
 }
 
 .quadrantView {
@@ -312,18 +301,41 @@
     }
     .horizontalList {
       div {
-        min-width: 70vw;
+        min-width: 60vw;
         max-width: 80vw;
         margin-bottom: 40px;
       }
     }
+    .quadrantRadar {
+      transform: scale(1.2);
+    }
   }
-
   @media only screen and (max-width: 767px) {
     padding-top: 90px !important;
+    width: 100vw;
     .horizontalList {
+      margin-top: -40px;
       div {
-        margin-bottom: 100px;
+        margin-bottom: 100px !important;
+      }
+      @media only screen and (max-width: 571px) {
+        margin-top: -100px;
+      }
+      @media only screen and (max-width: 392px) {
+        margin-top: -200px;
+      }
+    }
+    .quadrantRadar {
+      transform: scale(1);
+      margin-top: -40px;
+
+      @media only screen and (max-width: 571px) {
+        transform: scale(0.7);
+        margin-top: -40px;
+      }
+      @media only screen and (max-width: 392px) {
+        transform: scale(0.4);
+        margin-top: -100px;
       }
     }
   }

--- a/src/pages/views/RadarView.scss
+++ b/src/pages/views/RadarView.scss
@@ -130,8 +130,8 @@
 
 @media only screen and (max-width: 600px) {
   .radarTitle {
-    font-size: 23px !important;
-    margin: 160px 20px 20px 20px !important;
+    // font-size: 23px !important;
+    // margin: 160px 20px 20px 20px !important;
   }
 }
 
@@ -238,5 +238,93 @@
 @media only screen and (max-width: 767px) {
   .radarTitleContainer {
     display: none;
+  }
+  .option-button {
+    display: none;
+  }
+  .radarContainer {
+    path,
+    circle {
+      display: none;
+    }
+
+    text {
+      &.horizon-text {
+        display: none;
+      }
+    }
+
+    g.quadrant-text {
+      scale: 1.9;
+
+      &.quadrant-preparedness {
+        translate: 1.5vw 15.5vh;
+        position: relative;
+      }
+
+      &.quadrant-response {
+        translate: -5.5vw 15.5vh;
+      }
+
+      &.quadrant-mitigation {
+        translate: 5.5vw -15.5vh;
+      }
+
+      &.quadrant-recovery {
+        translate: -5.5vw -15.5vh;
+      }
+    }
+
+    .tabsComponents {
+      display: none;
+    }
+
+    .radarComponents {
+      width: 100vw;
+      @media only screen and (max-width: 571px) {
+        transform: scale(0.7);
+
+        div:first-of-type {
+          display: flex;
+          justify-content: center;
+          overflow: visible !important;
+        }
+      }
+
+      @media only screen and (max-width: 392px) {
+        transform: scale(0.4);
+      }
+    }
+
+    .maturity-levels-desc {
+      display: none;
+    }
+  }
+}
+
+.quadrantView {
+  @media only screen and (max-width: 1130px) {
+    flex-direction: column;
+    align-items: center;
+
+    button {
+      align-self: flex-start;
+    }
+    .horizontalList {
+      div {
+        min-width: 70vw;
+        max-width: 80vw;
+        margin-bottom: 40px;
+      }
+    }
+  }
+
+  @media only screen and (max-width: 767px) {
+    padding-top: 90px !important;
+    .horizontalList {
+      div {
+        margin-bottom: 100px;
+      }
+    }
   }
 }

--- a/src/pages/views/RadarView.tsx
+++ b/src/pages/views/RadarView.tsx
@@ -63,7 +63,7 @@ export const RadarView: React.FC<{ loading: boolean }> = ({ loading }) => {
         columns={{ sm: 1, md: 1, lg: 2 }}
         className='radarContainer'
       >
-        <Box>
+        <Box className='radarComponentsContainer'>
           <Box className='radarComponents'>
             {loading && <WaitingForRadar size='620px' />}
             {!loading && <Radar />}


### PR DESCRIPTION
The radar should be as in the same height as the information car. If we consider the page is divided into two and the left side of the divided part allocates 60% of the page while the right side allocates 40%.

The radar should be on the left side and the information card should be on the right side.

There should be a gap between the radar and the information card.

There should be a gap between the navbar and the radar; information card and the right-side screen limitation.
Responsiveness of any type of screen and mobile should also be considered

**Screenshots**

<img width="1510" alt="Screenshot 2022-09-16 at 08 33 17" src="https://user-images.githubusercontent.com/4943363/190564091-aea5f27d-e40c-4770-9c8f-548183b2a6f6.png">


![localhost_3000_ (2)](https://user-images.githubusercontent.com/4943363/190564039-b89693e7-8ca6-4b4d-93c9-57c70b5d7b4f.png)


![localhost_3000_ (3)](https://user-images.githubusercontent.com/4943363/190564066-0a2ada50-88f3-4e19-853f-019ba0775844.png)


![localhost_3000_ (4)](https://user-images.githubusercontent.com/4943363/190564067-5372a7e2-0296-4b8b-afa9-fb888bab86da.png)


![localhost_3000_ (5)](https://user-images.githubusercontent.com/4943363/190564070-e002293c-f5bf-4ccb-809d-bb637ae5dbe1.png)
