### PR TITLE
Fit project tab in available width in mobile view

### DIFF
--- a/src/pages/views/RadarView.scss
+++ b/src/pages/views/RadarView.scss
@@ -374,11 +374,9 @@
       tr {
         display: flex;
         flex-direction: column;
-        width: 100vw;
 
         td {
           padding: 16px 5px;
-          width: 75vw;
           &:first-of-type {
             font-weight: bold;
           }


### PR DESCRIPTION
<img width="635" alt="Screenshot 2022-09-29 at 14 09 41" src="https://user-images.githubusercontent.com/4943363/193016520-6bfb302b-8edd-4177-b0b6-90b3712b0aac.png">
