### PR TITLE
Set up radar state context

### DIFF
--- a/src/navigation/AppNav.tsx
+++ b/src/navigation/AppNav.tsx
@@ -4,39 +4,60 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import { ROUTES } from './routes';
 // Components
 import { AppLeftNav, AppMobileHeader, AppBottomNav } from '../components';
+import { Radar, useRadarState } from '@undp_sdg_ai_lab/undp-radar';
 
 // Layouts
 import { MainLayout } from '../ui/MainLayout';
 import { RadarLayout } from '../layouts/RadarLayout';
 // Pages
-import { NotFound404, Radar, Search, About, Volunteers, Home } from '../pages';
+import {
+  NotFound404,
+  Radar as RadarComponent,
+  Search,
+  About,
+  Volunteers,
+  Home
+} from '../pages';
 // Views
 import { QuadrantView } from '../pages/views/QuadrantView';
+// Context
+import { RadarContext, RadarContextInterface } from './context';
 
 // Styles
 import './AppNav.scss';
 
-export const NavApp: React.FC = () => (
-  <Flex className='navApp'>
-    <AppLeftNav />
-    <AppBottomNav />
-    <AppMobileHeader />
-    <MainLayout>
-      <Routes>
-        <Route path={ROUTES.HOME} element={<Home />} />
-        <Route path={ROUTES.RADAR} element={<RadarLayout />}>
-          <Route path={''} element={<Radar />}></Route>
-          <Route path={ROUTES.QUADRANT}>
-            <Route path={ROUTES.QUADRANT_PARAM} element={<QuadrantView />} />
-          </Route>
-        </Route>
-        <Route path={ROUTES.ABOUT} element={<About />} />
-        <Route path={ROUTES.SEARCH} element={<Search />} />
-        <Route path={ROUTES.VOLUNTEERS} element={<Volunteers />} />
+export const NavApp: React.FC = () => {
+  const radarContext: RadarContextInterface = {
+    Radar,
+    useRadarState
+  };
+  return (
+    <RadarContext.Provider value={radarContext}>
+      <Flex className='navApp'>
+        <AppLeftNav />
+        <AppBottomNav />
+        <AppMobileHeader />
+        <MainLayout>
+          <Routes>
+            <Route path={ROUTES.HOME} element={<Home />} />
+            <Route path={ROUTES.RADAR} element={<RadarLayout />}>
+              <Route path={''} element={<RadarComponent />}></Route>
+              <Route path={ROUTES.QUADRANT}>
+                <Route
+                  path={ROUTES.QUADRANT_PARAM}
+                  element={<QuadrantView />}
+                />
+              </Route>
+            </Route>
+            <Route path={ROUTES.ABOUT} element={<About />} />
+            <Route path={ROUTES.SEARCH} element={<Search />} />
+            <Route path={ROUTES.VOLUNTEERS} element={<Volunteers />} />
 
-        <Route path='/' element={<Navigate replace to={ROUTES.RADAR} />} />
-        <Route path='*' element={<NotFound404 />} />
-      </Routes>
-    </MainLayout>
-  </Flex>
-);
+            <Route path='/' element={<Navigate replace to={ROUTES.RADAR} />} />
+            <Route path='*' element={<NotFound404 />} />
+          </Routes>
+        </MainLayout>
+      </Flex>
+    </RadarContext.Provider>
+  );
+};

--- a/src/navigation/context.tsx
+++ b/src/navigation/context.tsx
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+export interface RadarContextInterface {
+  Radar: React.FC;
+  useRadarState: Function;
+}
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+export const RadarContext = createContext({} as RadarContextInterface);

--- a/src/radar/components/svg-hover/HorizonsNameComp.tsx
+++ b/src/radar/components/svg-hover/HorizonsNameComp.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/prop-types */
-import React from 'react';
 import { ReactLabelComp } from '@undp_sdg_ai_lab/undp-radar';
 
 import './NameComp.scss';


### PR DESCRIPTION
We currently fetch the radar state from the @undp_sdg_ai_lab/undp-radar package which should ideally return updated values with any state changes. There have however been some discrepancies observed in radar state when both technology filters and parameters are selected. This discrepancy can be better managed if we have an updated global state within the tech radar codebase as a source of truth. Here we will need to apply the react context api to consume the radar state from @undp_sdg_ai_lab/undp-radar and then use context api to serve any further radar states needed in the app