### PR TITLE
Remove title on mobile screen

### DIFF
--- a/src/pages/Home.scss
+++ b/src/pages/Home.scss
@@ -46,3 +46,7 @@ a .launchBtnDesktop {
     display: none;
   }
 }
+
+.hideTitleCopy {
+  display: none;
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -16,81 +16,87 @@ import UNDPLogo from '../assets/landing/UNDP-Logo-Blue-Small.png';
 import UNDPDRTLogo from '../assets/landing/UNDP_DRT.png';
 import CBILogo from '../assets/landing/cbi_logo.png';
 import SDGAILabLogo from '../assets/landing/sdg_ai_lab.png';
+import cx from 'classnames';
 
 import './Home.scss';
+import { useMediaQuery } from '@mui/material';
 
-export const Home: React.FC = () => (
-  <Flex w={'full'} h={'100vh'} overflowY={'auto'} flexDirection={'row'}>
-    <Flex w={useBreakpointValue({ base: '0', md: '30vw' })} h={'100vh'}>
-      <VStack justify={'space-between'}>
-        <chakra.p
-          fontWeight='500'
-          color='#334683'
-          padding={'0 10px'}
-          lineHeight={1.5}
-          fontSize={useBreakpointValue({ base: '1xl', md: '2xl' })}
-          textAlign={'center'}
-          letterSpacing='3px'
-          marginTop='200px'
-        >
-          FRONTIER TECHNOLOGY RADAR FOR DISASTER RISK REDUCTION (FTR4DRR)
-        </chakra.p>
-        <Stack>
+export const Home: React.FC = () => {
+  const isMobile = useMediaQuery('(max-width:767px)');
+  return (
+    <Flex w={'full'} h={'100vh'} overflowY={'auto'} flexDirection={'row'}>
+      <Flex w={useBreakpointValue({ base: '0', md: '30vw' })} h={'100vh'}>
+        <VStack justify={'space-between'}>
+          <chakra.p
+            fontWeight='500'
+            color='#334683'
+            padding={'0 10px'}
+            lineHeight={1.5}
+            fontSize={useBreakpointValue({ base: '1xl', md: '2xl' })}
+            textAlign={'center'}
+            letterSpacing='3px'
+            marginTop='200px'
+            className={cx({ hideTitleCopy: isMobile })}
+          >
+            FRONTIER TECHNOLOGY RADAR FOR DISASTER RISK REDUCTION (FTR4DRR)
+          </chakra.p>
+          <Stack>
+            <MenuItem to={ROUTES.RADAR}>
+              <Button
+                size='lg'
+                borderRadius='8px'
+                borderWidth='2px'
+                marginTop={'-60px'}
+                colorScheme='blue'
+                className='launchBtnDesktop'
+              >
+                Launch Radar
+              </Button>
+            </MenuItem>
+          </Stack>
+          <div className='partnersList'>
+            <Image
+              src={UNDPDRTLogo}
+              alt='UNDP DRT Logo'
+              className='UNDPDRTLogo'
+            />
+            <Image
+              src={SDGAILabLogo}
+              alt='SDG AI Lab Logo'
+              className='SDGAILogo'
+            />
+            <Image src={CBILogo} alt='CBI Logo' className='CBILogo' />
+          </div>
+        </VStack>
+      </Flex>
+      <Flex
+        w={useBreakpointValue({ base: '100vw', md: '70vw' })}
+        h={'100vh'}
+        backgroundImage={background}
+        backgroundPosition={'center'}
+        backgroundRepeat='no-repeat'
+        backgroundSize={'cover'}
+        flexDirection={'column'}
+      >
+        <Image
+          src={UNDPLogo}
+          alt='UNDP Logo'
+          className='UNDPLogo'
+          onClick={() => window.open('https://www.undp.org/', '_newtab')}
+        />
+        <div className='launchBtnMobile'>
           <MenuItem to={ROUTES.RADAR}>
             <Button
               size='lg'
               borderRadius='8px'
               borderWidth='2px'
-              marginTop={'-60px'}
               colorScheme='blue'
-              className='launchBtnDesktop'
             >
               Launch Radar
             </Button>
           </MenuItem>
-        </Stack>
-        <div className='partnersList'>
-          <Image
-            src={UNDPDRTLogo}
-            alt='UNDP DRT Logo'
-            className='UNDPDRTLogo'
-          />
-          <Image
-            src={SDGAILabLogo}
-            alt='SDG AI Lab Logo'
-            className='SDGAILogo'
-          />
-          <Image src={CBILogo} alt='CBI Logo' className='CBILogo' />
         </div>
-      </VStack>
+      </Flex>
     </Flex>
-    <Flex
-      w={useBreakpointValue({ base: '100vw', md: '70vw' })}
-      h={'100vh'}
-      backgroundImage={background}
-      backgroundPosition={'center'}
-      backgroundRepeat='no-repeat'
-      backgroundSize={'cover'}
-      flexDirection={'column'}
-    >
-      <Image
-        src={UNDPLogo}
-        alt='UNDP Logo'
-        className='UNDPLogo'
-        onClick={() => window.open('https://www.undp.org/', '_newtab')}
-      />
-      <div className='launchBtnMobile'>
-        <MenuItem to={ROUTES.RADAR}>
-          <Button
-            size='lg'
-            borderRadius='8px'
-            borderWidth='2px'
-            colorScheme='blue'
-          >
-            Launch Radar
-          </Button>
-        </MenuItem>
-      </div>
-    </Flex>
-  </Flex>
-);
+  );
+};


### PR DESCRIPTION
When the homepage is accessed on a mobile screen, depending on the network speed the background image may take a little while to load. Before it loads we see the tech radar title that should only appear on the desktop version.
We should fix this with a loading state if necessary or remove the desktop title.

<img width="413" alt="Screenshot 2022-12-21 at 08 56 58" src="https://user-images.githubusercontent.com/4943363/208833024-f136ec76-f1a3-4b25-a260-84ef7c42256d.png">
