### PR TITLE
Fix more button on mobile quadrant page.

### DIFF
--- a/src/pages/views/QuadrantView.scss
+++ b/src/pages/views/QuadrantView.scss
@@ -16,7 +16,7 @@
   flex: 1;
   padding: 2px;
 
-  button {
+  button.backButton {
     align-self: flex-start;
   }
 
@@ -39,7 +39,7 @@
     align-items: center;
     flex-direction: column;
 
-    button {
+    button.backButton {
       align-self: flex-start;
       position: absolute;
       z-index: 8;

--- a/src/radar/components/BackButton.tsx
+++ b/src/radar/components/BackButton.tsx
@@ -25,6 +25,7 @@ export const BackButton: React.FC<Props> = ({ to }) => {
       }): JSX.Element => (
         <IconButton
           aria-label=''
+          className='backButton'
           marginLeft={1}
           background='white'
           color='DodgerBlue'


### PR DESCRIPTION
On the mobile view after clicking on a quadrant,  when in the Stages tab, the 2nd click leads to the `More` button appearing on the top next to the back arrow. This `More` should be in the details of the information card.

![Screenshot 2022-12-20 at 09 24 14](https://user-images.githubusercontent.com/4943363/208834346-f1ea6066-10e6-4320-a804-6dbea98389ad.png)
