### PR TITLE
Fix scroll issue on quadrant page

### DIFF
--- a/src/pages/search/SearchBar.tsx
+++ b/src/pages/search/SearchBar.tsx
@@ -35,7 +35,7 @@ export const SearchBar: React.FC = () => {
           merge[existingIndex]['Disaster Cycle'] = merge[existingIndex][
             'Disaster Cycle'
           ]
-            .concat(', ')
+            .concat(',')
             .concat(item['Disaster Cycle']);
         }
       } else {

--- a/src/pages/views/QuadrantView.scss
+++ b/src/pages/views/QuadrantView.scss
@@ -9,6 +9,12 @@
   @media only screen and (max-width: 1180px) {
     padding-top: 55px;
   }
+
+  svg {
+    @media only screen and (min-width: 1900px) {
+      position: fixed;
+    }
+  }
 }
 
 .quadrantView {
@@ -18,6 +24,7 @@
 
   button.backButton {
     align-self: flex-start;
+    position: fixed;
   }
 
   @media only screen and (max-height: 725px) {
@@ -33,6 +40,11 @@
 
   .quadrantTitle {
     text-align: center;
+    @media only screen and (min-width: 1900px) {
+      position: fixed;
+      width: 50%;
+      top: 95px;
+    }
   }
 
   @media only screen and (max-width: 1180px) {


### PR DESCRIPTION
On wide screens (>2000px) the quadrant would move out of the screen when we scroll the information card section.