### PR TITLE
Feature/444 add how to help option

### DIFF
--- a/src/components/pageDetails/PageDetails.tsx
+++ b/src/components/pageDetails/PageDetails.tsx
@@ -11,6 +11,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { supabase } from 'helpers/databaseClient';
 import { updateDataVersion } from 'helpers/dataUtils';
 import { isAdmin } from 'components/shared/helpers/auth';
+import { toSnakeCase } from 'components/shared/helpers/HelperUtils';
 
 interface Props {
   item: Record<string, string | string[] | number>;
@@ -149,7 +150,7 @@ export const PageDetails: React.FC<Props> = ({
                   <span className='itemDetailsTitle'>
                     {section.toLocaleUpperCase()}
                   </span>
-                  <p className='itemDetailsContent'>{itemDetails[section]}</p>
+                  <p className='itemDetailsContent'>{itemDetails[toSnakeCase(section)]}</p>
                 </section>
                 <hr className='separater' />
               </div>

--- a/src/components/pageDetails/PageDetails.tsx
+++ b/src/components/pageDetails/PageDetails.tsx
@@ -118,13 +118,16 @@ export const PageDetails: React.FC<Props> = ({
 
       <div className='itemBody'>
         <div className='itemToc'>
-          {sections.map((section: string, idx: number) => (
+          {sections
+            .filter(section =>
+              section.toLowerCase() !== 'how to help' || helpNeeded
+            )
+            .map((section: string, idx: number) => (
             <a
               className={cx({ bolden: selectedSection === section })}
               key={idx}
               onClick={() => {
                 handleScroll(section.replace(/\s+/g, '_'));
-
                 setSelectedSection(section);
               }}
             >
@@ -133,18 +136,25 @@ export const PageDetails: React.FC<Props> = ({
           ))}
         </div>
         <div className='itemContent'>
-          {sections.map((section: string, idx: number) => (
-            <div key={idx}>
-              <section id={section.replace(/\s+/g, '_')}>
-                <span className='itemDetailsTitle'>
-                  {section.toLocaleUpperCase()}
-                </span>
+          {sections.map((section: string, idx: number) => {
+            const lowerCaseSection = section.toLowerCase();
 
-                <p className='itemDetailsContent'>{itemDetails[section]}</p>
-              </section>
-              <hr className='separater' />
-            </div>
-          ))}
+            if (lowerCaseSection === 'how to help' && !helpNeeded) {
+              return null;
+            }
+
+            return (
+              <div key={idx}>
+                <section id={section.replace(/\s+/g, '_')}>
+                  <span className='itemDetailsTitle'>
+                    {section.toLocaleUpperCase()}
+                  </span>
+                  <p className='itemDetailsContent'>{itemDetails[section]}</p>
+                </section>
+                <hr className='separater' />
+              </div>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/src/pages/eventAction/EventAction.tsx
+++ b/src/pages/eventAction/EventAction.tsx
@@ -63,6 +63,7 @@ export const EventAction: React.FC<Props> = ({ mode }) => {
       setFormValues(currentItem);
     }
     void getLocations();
+
   }, []);
 
   const getLocations = async (): Promise<void> => {

--- a/src/pages/eventAction/EventAction.tsx
+++ b/src/pages/eventAction/EventAction.tsx
@@ -29,7 +29,8 @@ const initialFormValues = {
   contacts: '',
   solutions: '',
   resources: '',
-  help_needed: 0
+  help_needed: 0,
+  how_to_help: ''
 };
 
 export const EventAction: React.FC<Props> = ({ mode }) => {
@@ -81,8 +82,27 @@ export const EventAction: React.FC<Props> = ({ mode }) => {
       payload[item] = `{${payload[item]}}`;
     });
 
-    if (Object.values(payload).includes(''))
-      return alert('Please fill all fields');
+    const alwaysRequiredFields: Array<keyof typeof payload> = [
+      'title',
+      'overview',
+      'img_url',
+      'impact',
+      'source',
+      'summary',
+      'contacts',
+      'solutions',
+      'resources',
+    ];
+
+    const missingRequiredField = alwaysRequiredFields.find(field => !payload[field]);
+    if (missingRequiredField) {
+      return alert(`Please fill the required field: ${missingRequiredField}`);
+    }
+
+    if (Number(payload['help_needed']) === 1 && !payload['how_to_help']) {
+      return alert('Please provide details on how to help when "Help Needed?" is checked.');
+    }
+
     payload['slug'] = toSnakeCase(formValues.title as string);
     let supabaseError = false;
     if (mode.toLocaleLowerCase() === 'add') {
@@ -234,7 +254,7 @@ export const EventAction: React.FC<Props> = ({ mode }) => {
           <FormLabel textAlign={'end'}>Help Needed?</FormLabel>
           <Checkbox
             name='help_needed'
-            isChecked={formValues['help_needed'] === 1}
+            isChecked={Number(formValues['help_needed']) === 1}
             onChange={(e) =>
               setFormValues((prevState) => ({
                 ...prevState,
@@ -243,6 +263,20 @@ export const EventAction: React.FC<Props> = ({ mode }) => {
             }
           />
         </FormControl>
+
+        {Number(formValues['help_needed']) === 1 && (
+          <FormControl display={'flex'} gap={3} mb={5}>
+            <FormLabel textAlign={'end'}>How to Help</FormLabel>
+            <Textarea
+              w={'100%'}
+              name='how_to_help'
+              value={formValues['how_to_help'] as string ?? ''}
+              size='sm'
+              onChange={handleChange}
+              data-testid='field-how_to_help'
+            />
+          </FormControl>
+        )}
 
         <div className='submitBtn'>
           <Button


### PR DESCRIPTION
Changes:

New Disaster Event Form:
Only when the "help needed" checkbox is checked, the "How to help" text input area is displayed and becomes mandatory. Otherwise, it is hidden.

Disaster Detail View:
The "How to help" section is now displayed only when the "help needed" flag is set for the disaster event.

Background:

Based on the requirements of Issue #444, this change allows for clear management and display of whether help is needed for a disaster and the specific ways to help if required.
Previously, the "How to help" section was displayed regardless of whether help was needed, and there was no means to record specific ways to help during creation.