### PR TITLE
Fix endless loading spinner #439

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { HashRouter } from 'react-router-dom';
-
+import { chakra } from '@chakra-ui/react';
 import { NavApp } from './navigation/AppNav';
 import { AppRadarProvider } from './radar/RadarProvider';
 import { AppUiProvider } from './ui/AppUiProvider';
 import { getDataVersion } from 'helpers/databaseClient';
+import loader from './assets/loader.svg';
 
 import './App.css';
 
@@ -15,9 +16,39 @@ import './App.css';
  * and replace HashRouter
  **/
 export const App: React.FC = () => {
+  const [isLoading, setIsLoading] = useState(true);
   useEffect(() => {
-    void getDataVersion();
+    const fetchDataVersion = async (): Promise<void> => {
+      try {
+        setIsLoading(true);
+        await getDataVersion();
+      } catch (err) {
+        console.error('Failed to fetch data version:', err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void fetchDataVersion();
   }, []);
+
+  if (isLoading) {
+    return (
+      <chakra.section
+        display={'flex'}
+        flexDirection={'row'}
+        alignItems={'center'}
+        justifyContent={'center'}
+        height={'100vh'}
+        fontWeight='500'
+        color='#334683'
+        gap={'10px'}
+      >
+        <img src={loader} alt='loading spinner' />
+        <span>Loading...</span>
+      </chakra.section>
+    );
+  }
 
   return (
     <AppUiProvider>

--- a/src/assets/loader.svg
+++ b/src/assets/loader.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+	<circle cx="12" cy="2" r="0" fill="#ADB3CC">
+		<animate attributeName="r" begin="0" calcMode="spline" dur="1s" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" repeatCount="indefinite" values="0;2;0;0" />
+	</circle>
+	<circle cx="12" cy="2" r="0" fill="#ADB3CC" transform="rotate(45 12 12)">
+		<animate attributeName="r" begin="0.125s" calcMode="spline" dur="1s" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" repeatCount="indefinite" values="0;2;0;0" />
+	</circle>
+	<circle cx="12" cy="2" r="0" fill="#ADB3CC" transform="rotate(90 12 12)">
+		<animate attributeName="r" begin="0.25s" calcMode="spline" dur="1s" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" repeatCount="indefinite" values="0;2;0;0" />
+	</circle>
+	<circle cx="12" cy="2" r="0" fill="#ADB3CC" transform="rotate(135 12 12)">
+		<animate attributeName="r" begin="0.375s" calcMode="spline" dur="1s" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" repeatCount="indefinite" values="0;2;0;0" />
+	</circle>
+	<circle cx="12" cy="2" r="0" fill="#ADB3CC" transform="rotate(180 12 12)">
+		<animate attributeName="r" begin="0.5s" calcMode="spline" dur="1s" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" repeatCount="indefinite" values="0;2;0;0" />
+	</circle>
+	<circle cx="12" cy="2" r="0" fill="#ADB3CC" transform="rotate(225 12 12)">
+		<animate attributeName="r" begin="0.625s" calcMode="spline" dur="1s" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" repeatCount="indefinite" values="0;2;0;0" />
+	</circle>
+	<circle cx="12" cy="2" r="0" fill="#ADB3CC" transform="rotate(270 12 12)">
+		<animate attributeName="r" begin="0.75s" calcMode="spline" dur="1s" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" repeatCount="indefinite" values="0;2;0;0" />
+	</circle>
+	<circle cx="12" cy="2" r="0" fill="#ADB3CC" transform="rotate(315 12 12)">
+		<animate attributeName="r" begin="0.875s" calcMode="spline" dur="1s" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" repeatCount="indefinite" values="0;2;0;0" />
+	</circle>
+</svg>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4604,9 +4604,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001517:
-  version "1.0.30001522"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001522.tgz#44b87a406c901269adcdb834713e23582dd71856"
-  integrity sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg==
+  version "1.0.30001716"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001716.tgz"
+  integrity sha512-49/c1+x3Kwz7ZIWt+4DvK3aMJy9oYXXG6/97JKsnjdCk/6n9vVyWL8NAwVt95Lwt9eigI10Hl782kDfZUUlRXw==
 
 capture-exit@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4604,9 +4604,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001517:
-  version "1.0.30001716"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001716.tgz"
-  integrity sha512-49/c1+x3Kwz7ZIWt+4DvK3aMJy9oYXXG6/97JKsnjdCk/6n9vVyWL8NAwVt95Lwt9eigI10Hl782kDfZUUlRXw==
+  version "1.0.30001522"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001522.tgz#44b87a406c901269adcdb834713e23582dd71856"
+  integrity sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Issue
The application was displaying an endless loading spinner in the browser tab due to improper handling of the getDataVersion() API call in the useEffect hook in the App.tsx file. This created a poor user experience and potentially masked underlying issues with data fetching.

Solution
Added proper loading state management with useState to track when data is being fetched
Implemented a structured async/await pattern with proper error handling
Added a try/catch/finally block to ensure loading state is properly updated regardless of API response
Created a user-friendly loading indicator using Chakra UI components and an SVG loader
Separated the loading UI from the main application rendering for cleaner code organization

Testing
Verified that the loading indicator appears and disappears correctly when data is fetched
Confirmed the browser tab no longer shows an endless loading spinner