### PR TITLE
Format multi-select drop down

### DIFF
--- a/src/pages/eventAction/EventAction.scss
+++ b/src/pages/eventAction/EventAction.scss
@@ -14,4 +14,10 @@
   .selectMultiple {
     min-width: 300px;
   }
+  .rmsc .select-item {
+    &.selected,
+    &:hover {
+      width: 100%;
+    }
+  }
 }

--- a/src/pages/eventAction/EventAction.tsx
+++ b/src/pages/eventAction/EventAction.tsx
@@ -43,6 +43,7 @@ export const EventAction: React.FC<Props> = ({ mode }) => {
   const [formValues, setFormValues] = useState<FormProps>(initialFormValues);
   const [locations, setLocations] = useState<any>([]);
   const [countries, setCountries] = useState<any>([]);
+  const [selectedCountries, setSelectedCountries] = useState<any>([]);
 
   const handleChange = (
     e:
@@ -97,9 +98,13 @@ export const EventAction: React.FC<Props> = ({ mode }) => {
     return selectedValues;
   };
 
+  useEffect(() => {
+    setSelectedCountries(getSelectedValues(formValues['countries']));
+  }, [locations]);
+
   const getOptions = (): any =>
     locations.reduce((a: any, c: any) => {
-      a.push({ label: c.country, value: c.id });
+      a.push({ label: c.country, value: c.country });
       return a;
     }, []);
 
@@ -267,13 +272,15 @@ export const EventAction: React.FC<Props> = ({ mode }) => {
         </FormControl>
         <FormControl display={'flex'} gap={3} mb={5}>
           <FormLabel textAlign={'end'}>Countries</FormLabel>
-          <SelectMultiple
-            options={getOptions()}
-            loading={false}
-            label={'countries'}
-            onChange={setCountries}
-            selectedValues={getSelectedValues(formValues['countries'])}
-          />
+          {(isCreateForm || selectedCountries.length > 0) && (
+            <SelectMultiple
+              options={getOptions()}
+              loading={false}
+              label={'countries'}
+              onChange={setCountries}
+              selectedValues={selectedCountries}
+            />
+          )}
         </FormControl>
         <FormControl display={'flex'} gap={3} mb={5}>
           <FormLabel textAlign={'end'}>Help Needed?</FormLabel>


### PR DESCRIPTION
Ensures that previously selected countries in the disaster events form will still be selected on editing a disaster event:

<img width="977" height="730" alt="Screenshot 2025-07-21 at 10 22 54" src="https://github.com/user-attachments/assets/80516be5-8595-400f-93c3-a6e81af7e9d2" />
