### PR TITLE
Fix blank Disasters page when project badges lack cycle fields.

### DIFF
--- a/src/components/shared/helpers/HelperUtils.ts
+++ b/src/components/shared/helpers/HelperUtils.ts
@@ -331,7 +331,10 @@ export const getParameterFilteredProjects = (
   return filteredProjects;
 };
 
-export const sliceForBadge = (projectArray: string[]): string[] => {
+export const sliceForBadge = (projectArray?: string[] | null): string[] => {
+  if (!Array.isArray(projectArray)) {
+    return [];
+  }
   if (projectArray.length > 2) {
     const sliced = projectArray.slice(0, 2);
     sliced.push('...');

--- a/src/components/shared/projectBadges/ProjectBadges.test.tsx
+++ b/src/components/shared/projectBadges/ProjectBadges.test.tsx
@@ -58,4 +58,25 @@ describe('ProjectBadge', () => {
     expect(screen.getByText(/Response/)).toBeInTheDocument();
     expect(screen.getByText(/Tonga/)).toBeInTheDocument();
   });
+
+  it('does not crash when disaster cycle and country fields are missing', () => {
+    renderBadge({
+      status: 'Idea',
+      title: 'Sparse API project'
+    });
+
+    expect(screen.getByText(/Idea/)).toBeInTheDocument();
+  });
+
+  it('accepts singular disaster_cycle and comma-separated country strings', () => {
+    renderBadge({
+      status: 'Validation',
+      disaster_cycle: 'Preparedness, Response',
+      country: 'Fiji, Samoa'
+    });
+
+    expect(screen.getByText(/Validation/)).toBeInTheDocument();
+    expect(screen.getByText(/Preparedness,Response/)).toBeInTheDocument();
+    expect(screen.getByText(/Fiji,Samoa/)).toBeInTheDocument();
+  });
 });

--- a/src/components/shared/projectBadges/ProjectBadges.tsx
+++ b/src/components/shared/projectBadges/ProjectBadges.tsx
@@ -11,7 +11,34 @@ interface Props {
   project: BlipType;
 }
 
+/** Normalize API snake_case, radar CSV fields, strings, or arrays into badge lists. */
+const toBadgeList = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value
+      .map(String)
+      .map((v) => v.trim())
+      .filter(Boolean);
+  }
+  if (typeof value === 'string' && value.trim()) {
+    return value
+      .split(',')
+      .map((v) => v.trim())
+      .filter(Boolean);
+  }
+  return [];
+};
+
 export const ProjectBadge: React.FC<Props> = ({ project }) => {
+  const disasterCycles = toBadgeList(
+    project['disaster_cycles'] ??
+      project['disaster_cycle'] ??
+      project['Disaster Cycle']
+  );
+  const countries = toBadgeList(
+    project['country'] ?? project['Country of Implementation']
+  );
+  const sdgs = toBadgeList(project['sdg'] ?? project['SDG']);
+
   return (
     <Stack direction='row' mt={3} mb={4} className='projectBadges'>
       <Badge
@@ -25,7 +52,7 @@ export const ProjectBadge: React.FC<Props> = ({ project }) => {
         🏠 {project['status'] || project['Status/Maturity']}
       </Badge>
 
-      {project['SDG'] && project['SDG'][0] !== 'No Information' && (
+      {sdgs.length > 0 && sdgs[0] !== 'No Information' && (
         <Badge
           px={2}
           py={1}
@@ -33,7 +60,7 @@ export const ProjectBadge: React.FC<Props> = ({ project }) => {
           bg='green.50'
           textTransform='capitalize'
         >
-          🎯 {' ' + sliceForBadge(project['sdg'] || project['SDG'])}
+          🎯 {' ' + sliceForBadge(sdgs)}
         </Badge>
       )}
 
@@ -45,11 +72,7 @@ export const ProjectBadge: React.FC<Props> = ({ project }) => {
         color='#fff'
         textTransform='capitalize'
       >
-        🌋{' '}
-        {' ' +
-          sliceForBadge(
-            project['disaster_cycles'] || project['Disaster Cycle'].split(',')
-          )}
+        🌋 {' ' + sliceForBadge(disasterCycles)}
       </Badge>
       <Badge
         px={2}
@@ -59,10 +82,7 @@ export const ProjectBadge: React.FC<Props> = ({ project }) => {
         textTransform='capitalize'
       >
         📍
-        {'' +
-          sliceForBadge(
-            project['country'] || project['Country of Implementation']
-          )}
+        {'' + sliceForBadge(countries)}
       </Badge>
     </Stack>
   );


### PR DESCRIPTION
Guard ProjectBadge against missing disaster cycle/country data from the API so sparse projects no longer crash the page.